### PR TITLE
json: Fix parsing numbers

### DIFF
--- a/Json.h
+++ b/Json.h
@@ -998,7 +998,7 @@ namespace DAB
 
         static bool isNum ( char const c )
         {
-            if (((c >= '0') && (c <= '9')) || (c == '+') || (c <= '-'))
+            if (((c >= '0') && (c <= '9')) || (c == '+') || (c == '-'))
             {
                 return true;
             }


### PR DESCRIPTION
This call was throwing "missing comma":
  DAB::jsonParser ( "{\"num\":0,\"str\": \"val\"}" );