### PR TITLE
Use MQTT5 specific connect, subscribe, and publish client operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ fabric.properties
 
 vcpkg_installed
 build
+
+.vscode
+.idea

--- a/dab.cpp
+++ b/dab.cpp
@@ -218,9 +218,13 @@ int main ( int argc, char *argv[] )
         // this connects the mqtt interface to the mqtt broker
         mqtt.connect ();
 
+        std::cout << "Connected to MQTT Broker!" << std::endl;
+
         // wait forever or until the connection with the broker is finished
         // a user can call mqtt.disconnect() to gracefully exit.
         mqtt.wait ();
+
+        std::cout << "Wait() finished, exiting" << std::endl;
     } catch ( DAB::dabException e )
     {
         std::cout << "error: " << e.errorCode << " " << e.errorText << std::endl;


### PR DESCRIPTION
Fixes the issue wherein the DAB Bridge exits prematurely without any response on the first message received.